### PR TITLE
[CLI] Add 'shared' command

### DIFF
--- a/cmd/gd/main.go
+++ b/cmd/gd/main.go
@@ -147,7 +147,15 @@ func gd(args ...string) error {
 			return tooling.Go.Exec(args...)
 		case "doc":
 			return doc(args[1:]...)
-		case "build", "run", "test":
+		case "help":
+			if len(args) > 1 && args[1] == "shared" {
+				return tooling.Go.Exec(append([]string{"help", "build"}, args[2:]...)...)
+			}
+			err := tooling.Go.Exec(args...)
+			fmt.Println(`gd commands:
+		shared	generate shared object/library for Godot`)
+			return err
+		case "build", "run", "test", "shared":
 		default:
 			return tooling.Go.Exec(args...)
 		}
@@ -305,6 +313,11 @@ func gd(args ...string) error {
 				}
 			}
 			return platform.Test(testArgs(args[1:]...)...)
+		case "shared":
+			if err := os.Chdir(project.Directory); err != nil {
+				return xray.New(err)
+			}
+			return platform.Build(args[1:]...)
 		}
 	}
 	return nil


### PR DESCRIPTION
I added a command that generates the shared object/library without running nor building the whole project.

It could be useful in automation (I save the Go file --> the shared object/library is generated) and when the
user wants to add a type to the Godot project.

Fixes #311.
